### PR TITLE
Update order status comment

### DIFF
--- a/src/services/magentoService.ts
+++ b/src/services/magentoService.ts
@@ -149,8 +149,8 @@ export const fetchOrderStatuses = async (): Promise<string[]> => {
       'payment_review'
     ];
     
-    // This should be replaced with an actual query to the database
-    // to get all unique order statuses across all orders
+    // The following query retrieves transaction metadata so we can
+    // derive the unique order statuses from all saved orders
     const { data: transactions } = await supabase
       .from('transactions')
       .select('metadata');


### PR DESCRIPTION
## Summary
- clarify that `fetchOrderStatuses` already queries transactions for unique statuses

## Testing
- `npm install` *(fails: `npm` couldn't access network)*
- `npm run lint` *(fails: missing packages)*