### PR TITLE
Use env vars for Supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for Supabase
+VITE_SUPABASE_URL="https://your-supabase-url.supabase.co"
+VITE_SUPABASE_ANON_KEY="your-anon-key"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Configuration
+
+Create a `.env` file in the project root based on `.env.example` and set your Supabase
+credentials:
+
+```sh
+cp .env.example .env
+```
+
+The variables `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` must be provided for the
+application to connect to Supabase.
+
+### Docker
+
+The provided `docker-compose.yml` uses these environment variables. Ensure they
+are set in your shell or in a `.env` file before running:
+
+```sh
+docker-compose up
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/2a884200-905e-4ae0-b256-eb9aae846465) and click on Share -> Publish.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
+      - VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
+

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://vlkcnndgtarduplyedyp.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZsa2NubmRndGFyZHVwbHllZHlwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzYyNDY0ODYsImV4cCI6MjA1MTgyMjQ4Nn0.jr1HnmnBjlyabBUafz6gFpjpjGrYMq4E3XckB0XCovE";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? "";
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? "";
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- read Supabase credentials from `import.meta.env`
- add `.env.example`
- document environment variables and docker usage
- provide simple Docker setup

## Testing
- `pytest -q` *(fails: command not found)*