### PR TITLE
Add Docker Compose with Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Running with Docker
+
+The project includes a `docker-compose.yml` file that starts the React dev server alongside a self-hosted Supabase stack.
+
+```bash
+docker compose up
+```
+
+The application will be available at `http://localhost:5173`. Supabase services listen on ports `54322`, `3600`, `4500`, and `5500`, and database files are stored in Docker volumes for persistence.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3.8'
+services:
+  app:
+    image: node:20
+    working_dir: /usr/src/app
+    command: sh -c "npm install && npm run dev"
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    ports:
+      - "5173:5173"
+    environment:
+      - HOST=0.0.0.0
+    depends_on:
+      - rest
+
+  db:
+    image: supabase/postgres:15
+    ports:
+      - "54322:5432"
+    volumes:
+      - supabase-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+
+  rest:
+    image: postgrest/postgrest:v12
+    ports:
+      - "3600:3600"
+    environment:
+      - PGRST_DB_URI=postgres://postgres:postgres@db:5432/postgres
+      - PGRST_DB_SCHEMA=public
+      - PGRST_DB_ANON_ROLE=anon
+      - PGRST_JWT_SECRET=super-secret-jwt
+      - PGRST_SERVER_PORT=3600
+    depends_on:
+      - db
+
+  realtime:
+    image: supabase/realtime:v2.29.0
+    ports:
+      - "4500:4500"
+    environment:
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_NAME=postgres
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - PORT=4500
+    depends_on:
+      - db
+
+  storage:
+    image: supabase/storage-api:v0.56.0
+    ports:
+      - "5500:5500"
+    environment:
+      - POSTGREST_URL=http://rest:3600
+      - PGRST_JWT_SECRET=super-secret-jwt
+      - ANON_KEY=super-secret-jwt
+      - SERVICE_KEY=super-secret-jwt
+      - PORT=5500
+    volumes:
+      - supabase-storage:/var/lib/storage
+    depends_on:
+      - rest
+
+volumes:
+  supabase-db:
+  supabase-storage:


### PR DESCRIPTION
## Summary
- add docker-compose.yml defining React and Supabase services
- explain Docker usage in README
- resolve port conflicts for Supabase services

## Testing
- `pytest -q` *(fails: `pytest` not installed)*