### PR TITLE
Update Dockerfile for static build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+RUN npm run build
+EXPOSE 8080
+CMD ["npx", "serve", "-s", "dist", "-l", "$PORT"]
 


### PR DESCRIPTION
## Summary
- build the project inside Docker and serve the `dist` folder
- expose the default port

## Testing
- `pytest -q` *(fails: command not found)*