### PR TITLE
Fix Docker build by updating Browserslist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm install \
+    && npx update-browserslist-db@latest || true
 COPY . .
 RUN npm run build
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- refresh Browserslist data during Docker build

## Testing
- `pytest -q` *(fails: command not found)*