### PR TITLE
Fix serve port for Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN npm install \
 COPY . .
 RUN npm run build
 EXPOSE 8080
-CMD ["npx", "serve", "-s", "dist", "-l", "$PORT"]
+CMD ["npx", "serve", "-s", "dist", "-l", "8080"]
 


### PR DESCRIPTION
## Summary
- serve the built app on port 8080

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*