### PR TITLE
Fix serve command to use PORT environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN npm install \
     && npx update-browserslist-db@latest || true
 COPY . .
 RUN npm run build
-EXPOSE 8080
-CMD ["npx", "serve", "-s", "dist", "-l", "$PORT"]
+ENV PORT 8080
+EXPOSE $PORT
+CMD ["sh", "-c", "npx serve -s dist -l $PORT"]
 


### PR DESCRIPTION
## Summary
- serve built files with sh so $PORT is expanded

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*