### PR TITLE
Update Dockerfile port usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,4 @@ RUN npm run build
 ENV PORT 8080
 EXPOSE $PORT
 CMD ["sh", "-c", "npx serve -s dist -l $PORT"]
-EXPOSE 8080
-CMD ["npx", "serve", "-s", "dist", "-l", "8080"]
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "serve": "^14.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
## Summary
- use `$PORT` environment variable to run `serve`
- include `serve` dependency in package.json

## Testing
- `pytest -q` *(fails: command not found)*