### PR TITLE
Fix serve command to rely on PORT variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,4 @@ RUN npm run build
 ENV PORT 8080
 EXPOSE $PORT
 CMD ["sh", "-c", "npx serve -s dist -l $PORT"]
-EXPOSE 8080
-CMD ["npx", "serve", "-s", "dist", "-l", "8080"]
 


### PR DESCRIPTION
## Summary
- clean up Dockerfile to use single serve command

## Testing
- `pytest -q` *(fails: command not found)*