### PR TITLE
Fix serve listen address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN npm run build
 
 ENV PORT 8080
 EXPOSE $PORT
-CMD ["sh", "-c", "npx serve -s dist -l $PORT"]
+CMD ["sh", "-c", "npx serve -s dist -l tcp://0.0.0.0:${PORT:-8080}"]
 


### PR DESCRIPTION
## Summary
- adjust Dockerfile serve command to bind to 0.0.0.0 and default to 8080

## Testing
- `pytest -q` *(fails: command not found)*