### PR TITLE
Fix serve listen address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN npm run build
 
 ENV PORT 8080
 EXPOSE $PORT
-CMD ["sh", "-c", "npx serve -s dist -l $PORT"]
+CMD ["sh", "-c", "npx serve -s dist -l tcp://0.0.0.0:${PORT:-8080}"]
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can generate a production build and serve it locally with:
 
 ```bash
 npm run build
-npx serve -s dist -l 8080
+npx serve -s dist -l tcp://0.0.0.0:8080
 ```
 
 The `Dockerfile` instead starts the development server with:
@@ -98,8 +98,8 @@ npm run dev -- --host 0.0.0.0
 
 ### Deploying to Railway
 
-When deploying to Railway, set the build command to `npm run build` and the
-start command to `npx serve -s dist -l 8080`.
+When deploying to Railway, set the build command to `npm run build` and either
+leave the start command empty or set it to `npx serve -s dist -l tcp://0.0.0.0:$PORT`.
 
 ## How can I deploy this project?
 


### PR DESCRIPTION
## Summary
- adjust Dockerfile serve command to bind to 0.0.0.0 and default to 8080
- update docs for new start command

## Testing
- `pytest -q` *(fails: command not found)*