### PR TITLE
Fix Railway deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ npm run dev -- --host 0.0.0.0
 ### Deploying to Railway
 
 When deploying to Railway, set the build command to `npm run build` and either
-leave the start command empty or set it to `npx serve -s dist -l tcp://0.0.0.0:$PORT`.
+use the new `npm start` script or set the start command to
+`npx serve -s dist -l tcp://0.0.0.0:$PORT`.
 
 ## How can I deploy this project?
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "npx serve -s dist -l tcp://0.0.0.0:$PORT"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add a `start` script for production
- update Railway deployment docs

## Testing
- `pytest -q` *(fails: command not found)*