### PR TITLE
Fix Dockerfile port handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN npm install \
     && npx update-browserslist-db@latest || true
 COPY . .
 RUN npm run build
+RUN npm install -g serve
 
-ENV PORT 8080
-EXPOSE $PORT
-CMD ["sh", "-c", "npx serve -s dist -l tcp://0.0.0.0:${PORT:-8080}"]
+EXPOSE 8080
+CMD ["serve", "-s", "dist", "-l", "tcp://0.0.0.0:$PORT"]
 


### PR DESCRIPTION
## Summary
- use `serve` globally in Dockerfile
- expose the correct port for Railway

## Testing
- `pytest -q` *(fails: command not found)*