### PR TITLE
Fix Dockerfile port handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN npm install \
     && npx update-browserslist-db@latest || true
 COPY . .
 RUN npm run build
+RUN npm install -g serve
 
-ENV PORT 8080
-EXPOSE $PORT
-CMD ["sh", "-c", "npx serve -s dist -l tcp://0.0.0.0:${PORT:-8080}"]
+ENV PORT=8080
+EXPOSE 8080
+CMD ["serve", "-s", "dist", "-l", "tcp://0.0.0.0:$PORT"]
 


### PR DESCRIPTION
## Summary
- set default `PORT` environment variable in Dockerfile

## Testing
- `pytest -q` *(fails: command not found)*