### PR TITLE
Fix port config for Railway deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start": "npx serve -s dist -l tcp://0.0.0.0:$PORT"
+    "start": "serve -s dist -l tcp://0.0.0.0:$PORT"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- update `start` script to always use `$PORT`

## Testing
- `pytest -q` *(fails: command not found)*