### PR TITLE
Fix: Simplify npm start script for Railway deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start": "serve -s dist -l tcp://0.0.0.0:$PORT"
+    "start": "serve -s dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
Changed the `scripts.start` in `package.json` from `serve -s dist -l tcp://0.0.0.0:$PORT` to `serve -s dist`.

This relies on the `serve` CLI's default behavior to pick up the `PORT` environment variable provided by the hosting environment (e.g., Railway). This should resolve the 502 error caused by the application listening on the wrong port when Railway uses `npm start` instead of the Dockerfile CMD.